### PR TITLE
beautifulsoup4 4.11.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<36]
+  # win32 failed to get install actions for noarch generic package
+  skip: True  # [py<36 or win32]
 
 outputs:
   - name: beautifulsoup4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ outputs:
         - pytest
       commands:
         - pip check
-        - pytest bs4 -vv
+        - pytest bs4 -vv  
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.10.0" %}
+{% set version = "4.11.1" %}
 
 package:
   name: beautifulsoup4
@@ -6,34 +6,37 @@ package:
 
 source:
   url: https://pypi.io/packages/source/b/beautifulsoup4/beautifulsoup4-{{ version }}.tar.gz
-  sha256: c23ad23c521d818955a4151a67d81580319d4bf548d3d49f4223ae041ff98891
+  sha256: ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693
 
 build:
   number: 0
+  skip: True  # [py<36]
 
 outputs:
   - name: beautifulsoup4
-    build:
-      noarch: python
     script: build_base.bat  # [win]
     script: build_base.sh  # [not win]
     requirements:
-      build:
-        - python                                 # [build_platform != target_platform]
       host:
-        - python >=3.6
+        - python
         - pip
+        - setuptools
+        - wheel
       run:
-        - python >=3.6
+        - python
         - soupsieve >=1.2
     test:
+      source_files:
+        - bs4/tests
       imports:
         - bs4
         - bs4.builder
-      commands:
-        - pip check
       requires:
         - pip
+        - pytest
+      commands:
+        - pip check
+        - pytest bs4
 
   - name: bs4
     build:
@@ -42,11 +45,21 @@ outputs:
       run:
         - {{ pin_subpackage('beautifulsoup4', max_pin="x.x.x") }}
     test:
+      source_files:
+        - bs4/tests
       imports:
         - bs4
+      requires:
+        - html5lib
+        - lxml
+        - pip
+        - pytest
+      commands:
+        - pip check
+        - pytest bs4 -vvv
 
 about:
-  home: http://www.crummy.com/software/BeautifulSoup/
+  home: https://www.crummy.com/software/BeautifulSoup/
   license: MIT
   license_family: MIT
   license_file: COPYING.txt
@@ -54,7 +67,7 @@ about:
   description: |
     Beautiful Soup is a library for pulling data out of HTML and XML files.
     It provides ways of navigating, searching, and modifying parse trees.
-  doc_url: http://beautiful-soup-4.readthedocs.io/en/latest/
+  doc_url: https://beautiful-soup-4.readthedocs.io/en/latest/
   doc_source_url: https://github.com/newvem/beautifulsoup4/blob/master/doc/source/index.rst
   dev_url: https://code.launchpad.net/beautifulsoup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,18 +25,6 @@ outputs:
       run:
         - python
         - soupsieve >=1.2
-    test:
-      source_files:
-        - bs4/tests
-      imports:
-        - bs4
-        - bs4.builder
-      requires:
-        - pip
-        - pytest
-      commands:
-        - pip check
-        - pytest bs4
 
   - name: bs4
     build:
@@ -50,13 +38,26 @@ outputs:
       imports:
         - bs4
       requires:
-        - html5lib
-        - lxml
         - pip
         - pytest
       commands:
         - pip check
-        - pytest bs4 -vvv
+        - pytest bs4 -vv
+
+test:
+  source_files:
+    - bs4/tests
+  imports:
+    - bs4
+    - bs4.builder
+  requires:
+    - html5lib
+    - lxml
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest bs4 -vv
 
 about:
   home: https://www.crummy.com/software/BeautifulSoup/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,31 +34,21 @@ outputs:
       run:
         - {{ pin_subpackage('beautifulsoup4', max_pin="x.x.x") }}
     test:
-      source_files:
-        - bs4/tests
       imports:
         - bs4
       requires:
         - pip
-        - pytest
       commands:
         - pip check
-        - pytest bs4 -vv  
 
 test:
-  source_files:
-    - bs4/tests
   imports:
     - bs4
     - bs4.builder
   requires:
-    - html5lib
-    - lxml
     - pip
-    - pytest
   commands:
     - pip check
-    - pytest bs4 -vv
 
 about:
   home: https://www.crummy.com/software/BeautifulSoup/


### PR DESCRIPTION
Changelog: https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/CHANGELOG
License: https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/LICENSE
Requirements: https://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/view/head:/setup.py

Actions: 
1. Skip `py<36`
2. Remove `noarch: python`
3. Remove `req/build`
4. Fix `python` in host and run
5. Add missing `setuptools` and `wheel`
6. Move `tests` from the `beautifulsoup4` output to the higher level (inside the output tests skipped at all)
7. Add `pytest` to the `bs4` output
8. Improve `test`
9. Fix home and urls with HTTPS